### PR TITLE
Updated class constructors on native cubeSQLServer file

### DIFF
--- a/PHP/Native/cubeSQLServer.php
+++ b/PHP/Native/cubeSQLServer.php
@@ -40,7 +40,7 @@ class inhead {
 		$r .= $this->reserved2;
 		return $r;
 	}
-	public function inhead($packetsize, $nfields, $command, $selector,$timeout) {
+	public function __construct($packetsize, $nfields, $command, $selector,$timeout) {
 		$this->signature = 'SQLS';//pack('V',[ord('S'),ord('Q'),ord('L'),ord('S')]);
 		$this->packetSize = pack('N',$packetsize);
 		$this->command = pack('C',$command);
@@ -72,7 +72,7 @@ class outhead {
 	public $numFields; //unsigned int					// number of fields in the command (I could use 2 bytes instead of 4)
 	public $reserved1; //unsigned short					// unused in this version
 	public $reserved2; //unsigned short					// unused in this version
-	function outhead($bytes) {
+	function __construct($bytes) {
 		$this->signature = substr($bytes,0,4);
 		$this->packetSize = unpack("NpacketSize",substr($bytes,4,4))["packetSize"];
 		$this->errorCode = unpack("nerrorCode",substr($bytes,8,2))["errorCode"];
@@ -119,7 +119,7 @@ class csqldb {
 	
 	//void (*trace)  (const char*, void*);		// trace function
 	//void			*traceArgument;				// user argument to be passed to the trace function
-	public function csqldb($host, $port, $username, $password, $timeout) {
+	public function __construct($host, $port, $username, $password, $timeout) {
 		$this->host = $host;
 		$this->port = $port;
 		$this->username = $username;


### PR DESCRIPTION
After including the native `cubeSQLServer.php` in my PHP project it displayed 3 errors to me:
![cubesql-php-errors](https://cloud.githubusercontent.com/assets/3932097/23716249/d6a4f13a-042f-11e7-96ae-2f0290e4e1de.PNG)

The reason was that the used constructors are [PHP4 constructors](http://php.net/manual/en/migration70.deprecated.php) that got depricated in the PHP7 Versions.

More about constructors in the [PHP reference](http://php.net/manual/en/language.oop5.decon.php)

I think no one uses PHP4 any longer. So it should be save to use the `__constructor`.
