### PR TITLE
Fixed error handling and cleaned code a bit.

### DIFF
--- a/PHP/JSON/cubeSQLServer.php
+++ b/PHP/JSON/cubeSQLServer.php
@@ -1,191 +1,216 @@
 <?php
 
-/*
-**	JSON over TCP PHP connector for CubeSQL
-** 	Only unencrypted connections are supported in this version.
-*/
+/**
+ *	JSON over TCP PHP connector for CubeSQL
+ *
+ * 	Only unencrypted connections are supported in this version.
+ *
+ * @author Marco Bambini <marco@sqlabs.com>
+ * @see    https://github.com/cubesql/connectors
+ */
 
+/**
+ * Class cubeSQLServer
+ */
+class cubeSQLServer
+{
+    /** @var  int Stores the error code. 0 means no error. */
+    public $errorCode;
 
-	class cubeSQLServer {
-		public $errorCode;
-    	public $errorMessage;
-    	public $socketTimeout;
-    	private $socket;
-    	
-    	public function connect($host, $port, $username, $password, $timeout = 12) {
-    		$this->_resetError();
-    		$this->socketTimeout = $timeout;
-    		
-    		// create socket
-    		$this->socket = @socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
-    		if ($this->socket === false) {
-    			$this->_setSocketError();
-    			return false;
-    		}
-    		
-    		// connect socket
-    		$ip = gethostbyname($host);
-    		$result = @socket_connect($this->socket, $ip, $port);
-    		if ($result === false) {
-    			$this->_setSocketError();
-    			return false;
-    		}
-    		
-    		// generate randpool
-    		$randpool = '';
-    		while (strlen($randpool) <= 10) $randpool .= mt_rand();
-    		
-    		// compute sha1 (randpool;username) in hex mode
-    		// on the server password is stored as BASE64(SHA1(SHA1(password)))
-    		$sha1_username = sha1($randpool.$username);
-    		$sha1_password = sha1($randpool.base64_encode(sha1(sha1($password, true), true)));
-    		
-    		// create and send json request
-    		$request = array ('command'=>'CONNECT','username'=>"$sha1_username",'password'=>"$sha1_password",'randpool'=>"$randpool");
-    		$json_request = json_encode($request);
-    		$data = $this->_sendRequest($json_request);
-    		
-    		// save results
-    		$this->errorCode = $data['errorCode'];
-    		$this->errorMessage = ( array_key_exists( 'errorMsg', $data ) ? $data[ 'errorMsg' ] : NULL );
-    		
-    		return !$this->isError();
-    	}
-    	
-    	public function connect_database($host, $port, $username, $password, $database) {
-    		$rc = $this->connect($host, $port, $username, $password, 12);
-    		if ($rc === false) return $rc;
-    		
-    		$this->execute("USE DATABASE $database;");
-			if ($rc === false) return $rc;
-			
-			return !$this->isError();
-    	}
-    	
-    	public function execute($sql) {
-    		$this->_resetError();
-    		$request = array ('command'=>'EXECUTE','sql'=>"$sql");
-    		$json_request = json_encode($request);
-    		$data = $this->_sendRequest($json_request);
-    		
-    		// save results
-    		$this->errorCode = $data['errorCode'];
-    		$this->errorMessage = ( array_key_exists( 'errorMsg', $data ) ? $data[ 'errorMsg' ] : NULL );
-    	}
-    	
-    	public function select($sql) {
-    		$this->_resetError();
-    		$request = array ('command'=>'SELECT','sql'=>"$sql");
-    		$json_request = json_encode($request);
-    		$data = $this->_sendRequest($json_request);
-    		if ($data === NULL) return NULL;
-    		
-    		// check if an error occurs
-    		if (array_key_exists('errorCode', $data)) {
-    			$this->errorCode = $data['errorCode'];
-    			$this->errorMessage = $data['errorMsg'];
-    			return NULL;
-    		}
-    		
-    		// return associative array
-    		return $data;
-    	}
-    	
-    	public function disconnect() {
-    		$this->_resetError();
-    		$request = array ('command'=>'DISCONNECT');
-    		$json_request = json_encode($request);
-    		$data = $this->_sendRequest($json_request);
-			socket_close($this->socket);
-    	}
-    	
-    	public function isError() {
-    		if ($this->errorCode != 0) return true;
-    		return false;
-    	}
-    	
-    	private function _resetError() {
-    		$this->errorCode = 0;
-    		$this->errorMessage = "";
-    	}
-    	
-    	private function _setJSONError() {
-    		$this->errorCode = json_last_error();
-    		switch($this->errorCode)
-			{
-				case JSON_ERROR_DEPTH:
-				$this->errorMessage = 'Maximum stack depth exceeded';
-				break;
+    /** @var  string Stores the error message. */
+    public $errorMessage;
 
-				case JSON_ERROR_CTRL_CHAR:
-				$this->errorMessage = 'Unexpected control character found';
-        		break;
-        		
-				case JSON_ERROR_SYNTAX:
-				$this->errorMessage = 'Syntax error, malformed JSON';
-        		break;
-        		
-        		case JSON_ERROR_STATE_MISMATCH:
-        		$this->errorMessage = 'Invalid or malformed JSON';
-        		break;
-        		
-				case JSON_ERROR_NONE:
-				$this->errorMessage = 'No errors';
-        		break;
-			}
-    	}
-    	
-    	private function _setSocketError() {
-    		$this->errorCode = socket_last_error();
-    		$this->errorMessage = socket_strerror($this->errorCode);
-    	}
-    	
-    	private function _sendRequest($json_request) {
-    		// write request
-    		$bytes = @socket_write($this->socket, $json_request);
-    		if ($bytes === false) {
-    			$this->_setSocketError();
-    			return;
-    		}
-    		
-    		// read reply with a specified timeout
-    		$is_timeout = false;
-    		$reply = '';
-    		$buf = '';
-    		$start = microtime(true);
-    		while (1) {
-    			$bytes = @socket_recv($this->socket, $buf, 8192, MSG_DONTWAIT);
-    			if ($bytes === false) {
-    				$end = microtime(true);
-					$wait_time = ($end-$start) * 1000000;
-					if ($wait_time >= ($this->socketTimeout * 1000000)) {$is_timeout = true; break;}					
-					continue;
-    			}
-				$reply .= $buf;
-				
-				// since there is no way to check when a JOSN packet is finished
-				// the only way is to try to decode it
-				//$reply = utf8_encode($reply);
-				if (($bytes == 2) && (strcmp($reply,"[]")==0)) return array(); // fix for empty recordset
-				$r = json_decode($reply, true);
-				if ($r != NULL) break;
-			}
-			
-    		// check for possible errors on exit
-    		if ($is_timeout == true) $this->_setSocketError();
-    		else if ($r == NULL) $this->_setJSONError();
-    		
-    		// uncomment these lines to add debug code
-    		/*
-    		$json_errors = array(
-    			JSON_ERROR_NONE => 'No error has occurred',
-   				JSON_ERROR_DEPTH => 'The maximum stack depth has been exceeded',
-    			JSON_ERROR_CTRL_CHAR => 'Control character error, possibly incorrectly encoded',
-    			JSON_ERROR_SYNTAX => 'Syntax error',);
- 			echo 'JSON Last Error : ', $json_errors[json_last_error()], PHP_EOL, PHP_EOL;
-    		*/
-    		
-    		return $r;
-    	}
-	}
-?>
+    /** @var  int */
+    public $socketTimeout;
+
+    /** @var   */
+    private $socket;
+
+    public function connect($host, $port, $username, $password, $timeout = 12)
+    {
+        $this->_resetError();
+        $this->socketTimeout = $timeout;
+
+        // create socket
+        $this->socket = @socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+        if ($this->socket === false) {
+            $this->_setSocketError();
+            return false;
+        }
+
+        // connect socket
+        $ip = gethostbyname($host);
+        $result = @socket_connect($this->socket, $ip, $port);
+        if ($result === false) {
+            $this->_setSocketError();
+            return false;
+        }
+
+        // generate randpool
+        $randpool = '';
+        while (strlen($randpool) <= 10) $randpool .= mt_rand();
+
+        // compute sha1 (randpool;username) in hex mode
+        // on the server password is stored as BASE64(SHA1(SHA1(password)))
+        $sha1_username = sha1($randpool . $username);
+        $sha1_password = sha1($randpool . base64_encode(sha1(sha1($password, true), true)));
+
+        // create and send json request
+        $request = array('command' => 'CONNECT', 'username' => "$sha1_username", 'password' => "$sha1_password", 'randpool' => "$randpool");
+        $json_request = json_encode($request);
+        $data = $this->_sendRequest($json_request);
+
+        // save results
+        $this->errorCode = $data['errorCode'];
+        $this->errorMessage = (array_key_exists('errorMsg', $data) ? $data['errorMsg'] : NULL);
+
+        return !$this->isError();
+    }
+
+    public function connect_database($host, $port, $username, $password, $database)
+    {
+        $rc = $this->connect($host, $port, $username, $password, 12);
+        if ($rc === false) return $rc;
+
+        $this->execute("USE DATABASE $database;");
+        if ($rc === false) return $rc;
+
+        return !$this->isError();
+    }
+
+    public function execute($sql)
+    {
+        $this->_resetError();
+        $request = array('command' => 'EXECUTE', 'sql' => "$sql");
+        $json_request = json_encode($request);
+        $data = $this->_sendRequest($json_request);
+
+        // save results
+        $this->errorCode = $data['errorCode'];
+        $this->errorMessage = (array_key_exists('errorMsg', $data) ? $data['errorMsg'] : NULL);
+    }
+
+    public function select($sql)
+    {
+        $this->_resetError();
+        $request = array('command' => 'SELECT', 'sql' => "$sql");
+        $json_request = json_encode($request);
+        $data = $this->_sendRequest($json_request);
+        if ($data === NULL) return NULL;
+
+        // check if an error occurs
+        if (array_key_exists('errorCode', $data)) {
+            $this->errorCode = $data['errorCode'];
+            $this->errorMessage = $data['errorMsg'];
+            return NULL;
+        }
+
+        // return associative array
+        return $data;
+    }
+
+    public function disconnect()
+    {
+        $this->_resetError();
+        $request = array('command' => 'DISCONNECT');
+        $json_request = json_encode($request);
+        $data = $this->_sendRequest($json_request);
+        socket_close($this->socket);
+    }
+
+    public function isError()
+    {
+        if ($this->errorCode != 0) return true;
+        return false;
+    }
+
+    private function _resetError()
+    {
+        $this->errorCode = 0;
+        $this->errorMessage = "";
+    }
+
+    private function _setJSONError()
+    {
+        $this->errorCode = json_last_error();
+        switch ($this->errorCode) {
+            case JSON_ERROR_DEPTH:
+                $this->errorMessage = 'Maximum stack depth exceeded';
+                break;
+
+            case JSON_ERROR_CTRL_CHAR:
+                $this->errorMessage = 'Unexpected control character found';
+                break;
+
+            case JSON_ERROR_SYNTAX:
+                $this->errorMessage = 'Syntax error, malformed JSON';
+                break;
+
+            case JSON_ERROR_STATE_MISMATCH:
+                $this->errorMessage = 'Invalid or malformed JSON';
+                break;
+
+            case JSON_ERROR_NONE:
+                $this->errorMessage = 'No errors';
+                break;
+        }
+    }
+
+    private function _setSocketError()
+    {
+        $this->errorCode = socket_last_error();
+        $this->errorMessage = socket_strerror($this->errorCode);
+    }
+
+    private function _sendRequest($json_request)
+    {
+        // write request
+        $bytes = @socket_write($this->socket, $json_request);
+        if ($bytes === false) {
+            $this->_setSocketError();
+            return;
+        }
+
+        // read reply with a specified timeout
+        $is_timeout = false;
+        $reply = '';
+        $buf = '';
+        $start = microtime(true);
+        while (1) {
+            $bytes = @socket_recv($this->socket, $buf, 8192, MSG_DONTWAIT);
+            if ($bytes === false) {
+                $end = microtime(true);
+                $wait_time = ($end - $start) * 1000000;
+                if ($wait_time >= ($this->socketTimeout * 1000000)) {
+                    $is_timeout = true;
+                    break;
+                }
+                continue;
+            }
+            $reply .= $buf;
+
+            // since there is no way to check when a JOSN packet is finished
+            // the only way is to try to decode it
+            //$reply = utf8_encode($reply);
+            if (($bytes == 2) && (strcmp($reply, "[]") == 0)) return array(); // fix for empty recordset
+            $r = json_decode($reply, true);
+            if ($r != NULL) break;
+        }
+
+        // check for possible errors on exit
+        if ($is_timeout == true) $this->_setSocketError();
+        else if ($r == NULL) $this->_setJSONError();
+
+        // uncomment these lines to add debug code
+        /*
+        $json_errors = array(
+            JSON_ERROR_NONE => 'No error has occurred',
+               JSON_ERROR_DEPTH => 'The maximum stack depth has been exceeded',
+            JSON_ERROR_CTRL_CHAR => 'Control character error, possibly incorrectly encoded',
+            JSON_ERROR_SYNTAX => 'Syntax error',);
+         echo 'JSON Last Error : ', $json_errors[json_last_error()], PHP_EOL, PHP_EOL;
+        */
+
+        return $r;
+    }
+}

--- a/PHP/Native/cubeSQLServer.php
+++ b/PHP/Native/cubeSQLServer.php
@@ -1,105 +1,133 @@
 <?php
 
-/*
-**	Native PHP connector for CubeSQL based on official C SDK
-** 	Only unencrypted connections are supported in this version
-**	but SSL can be used.
-*/
-
-// client -> server header
-class inhead {
-	public $signature; //unsigned int					// PROTOCOL_SIGNATURE defined as 'SQLS'
-	public $packetSize; //unsigned int					// size of the entire packet (header excluded)
-	public $command; //unsigned char					// main command
-	public $selector; //unsigned char					// sub command selector
-	public $flag1; //unsigned char						// bit field
-	public $flag2; //unsigned char						// bit field
-	public $flag3; //unsigned char						// bit field
-	public $encryptedPacket; //unsigned char			// kEmptyField, kAESNONE, kAES128, kAES192, kAES256
-	public $protocolVersion; //unsigned char			// always 3 in 2007, 4 in 2011
-	public $clientType; //unsigned char					// always 3 in 2007 and 2008
-	public $numFields; //unsigned int					// number of fields in the command (I could use 2 bytes instead of 4)
-	public $expandedSize; //unsigned int				// if packet is compressed, this is the expanded size of the packet
-	public $timeout; //unsigned int						// timeout value
-	public $reserved1; //unsigned short					// unused in this version
-	public $reserved2; //unsigned short					// unused in this version
-	public function to_bytes() {
-		$r = '';
-		$r .= $this->signature;
-		$r .= $this->packetSize;
-		$r .= $this->command;
-		$r .= $this->selector;
-		$r .= $this->flag1.$this->flag2.$this->flag3;
-		$r .= $this->encryptedPacket;
-		$r .= $this->protocolVersion;
-		$r .= $this->clientType;
-		$r .= $this->numFields;
-		$r .= $this->expandedSize;
-		$r .= $this->timeout;
-		$r .= $this->reserved1;
-		$r .= $this->reserved2;
-		return $r;
-	}
-	public function __construct($packetsize, $nfields, $command, $selector,$timeout) {
-		$this->signature = 'SQLS';//pack('V',[ord('S'),ord('Q'),ord('L'),ord('S')]);
-		$this->packetSize = pack('N',$packetsize);
-		$this->command = pack('C',$command);
-		$this->selector = pack('C',$selector);
-		$this->flag1 = pack('C',0x01); //CLIENT_SUPPORT_COMPRESSION
-		$this->flag2 = pack('C',0x00);
-		$this->flag3 = pack('C',0x00);
-		$this->encryptedPacket = pack('C',0); //kAESNONE
-		$this->numFields = pack('N',$nfields);
-		$this->expandedSize = pack('N',0);
-		$this->timeout = pack('N',$timeout);
-		$this->protocolVersion = pack('C',4); //k2011PROTOCOL;
-		$this->clientType = pack('C',0);
-		$this->reserved1 = pack('v',0);
-		$this->reserved2 = pack('v',0);
-	}
-};
-
-// server -> client header
-class outhead {
-	public $signature; //unsigned int					// PROTOCOL_SIGNATURE defined as 'SQLS'
-	public $packetSize; //unsigned int					// size of the entire packet (header excluded)
-	public $errorCode; //unsigned short					// 0 means no error
-	public $flag1; //unsigned char						// bit field
-	public $encryptedPacket; //unsigned char			// kEmptyField, kAESNONE, kAES128, kAES192, kAES256
-	public $expandedSize; //unsigned int				// if flag1 is COMPRESSED_PACKET this is the expanded size of the entire buffer
-	public $rows; //unsigned int						// number of rows in the cursor
-	public $cols; //unsigned int						// number of columns in the cursor (it could be 2 bytes instead of 4?)
-	public $numFields; //unsigned int					// number of fields in the command (I could use 2 bytes instead of 4)
-	public $reserved1; //unsigned short					// unused in this version
-	public $reserved2; //unsigned short					// unused in this version
-	function __construct($bytes) {
-		$this->signature = substr($bytes,0,4);
-		$this->packetSize = unpack("NpacketSize",substr($bytes,4,4))["packetSize"];
-		$this->errorCode = unpack("nerrorCode",substr($bytes,8,2))["errorCode"];
-		$this->flag1 = ord(substr($bytes,10,1));
-		$this->encryptedPacket = ord(substr($bytes,11,1));
-		$this->expandedSize = unpack("NexpandedSize",substr($bytes,12,4))["expandedSize"];
-		$this->rows = unpack("Nrows",substr($bytes,16,4))["rows"];
-		$this->cols = unpack("Ncols",substr($bytes,20,4))["cols"];
-		$this->numFields = unpack("NnumFields",substr($bytes,24,4))["numFields"];
-		$this->reserved1 = unpack("nreserved1",substr($bytes,28,2))["reserved1"];
-		$this->reserved2 = unpack("nreserved2",substr($bytes,30,2))["reserved2"];
-	}
-};
+/**
+ *    Native PHP connector for CubeSQL based on official C SDK
+ *
+ *    Only unencrypted connections are supported in this version
+ *    but SSL can be used.
+ *
+ * @author Marco Bambini <marco@sqlabs.com>
+ * @see    https://github.com/cubesql/connectors
+ */
 
 
-class csqldb {
-	public $timeout;					// timeout used in the socket I/O operations
-	public $sockfd;						// the socket
-	public $port;						// port used for the connection
-	public $host;					// hostname
-	public $username;				// username
-	public $password;				// password
-	public $errmsg;				// last error message
-	public $errcode;					// last error code
-//	public $useOldProtocol;				// flag to set if you want to use the old REALSQLServer protocol
-	public $verifyPeer;					// flag to check if peer verification must be performed
-	
+/**
+ * Class inhead
+ *
+ * client -> server header
+ */
+class inhead
+{
+    public $signature; //unsigned int					// PROTOCOL_SIGNATURE defined as 'SQLS'
+    public $packetSize; //unsigned int					// size of the entire packet (header excluded)
+    public $command; //unsigned char					// main command
+    public $selector; //unsigned char					// sub command selector
+    public $flag1; //unsigned char						// bit field
+    public $flag2; //unsigned char						// bit field
+    public $flag3; //unsigned char						// bit field
+    public $encryptedPacket; //unsigned char			// kEmptyField, kAESNONE, kAES128, kAES192, kAES256
+    public $protocolVersion; //unsigned char			// always 3 in 2007, 4 in 2011
+    public $clientType; //unsigned char					// always 3 in 2007 and 2008
+    public $numFields; //unsigned int					// number of fields in the command (I could use 2 bytes instead of 4)
+    public $expandedSize; //unsigned int				// if packet is compressed, this is the expanded size of the packet
+    public $timeout; //unsigned int						// timeout value
+    public $reserved1; //unsigned short					// unused in this version
+    public $reserved2; //unsigned short					// unused in this version
+
+    public function to_bytes()
+    {
+        $r = '';
+        $r .= $this->signature;
+        $r .= $this->packetSize;
+        $r .= $this->command;
+        $r .= $this->selector;
+        $r .= $this->flag1 . $this->flag2 . $this->flag3;
+        $r .= $this->encryptedPacket;
+        $r .= $this->protocolVersion;
+        $r .= $this->clientType;
+        $r .= $this->numFields;
+        $r .= $this->expandedSize;
+        $r .= $this->timeout;
+        $r .= $this->reserved1;
+        $r .= $this->reserved2;
+        return $r;
+    }
+
+    public function __construct($packetsize, $nfields, $command, $selector, $timeout)
+    {
+        $this->signature = 'SQLS';//pack('V',[ord('S'),ord('Q'),ord('L'),ord('S')]);
+        $this->packetSize = pack('N', $packetsize);
+        $this->command = pack('C', $command);
+        $this->selector = pack('C', $selector);
+        $this->flag1 = pack('C', 0x01); //CLIENT_SUPPORT_COMPRESSION
+        $this->flag2 = pack('C', 0x00);
+        $this->flag3 = pack('C', 0x00);
+        $this->encryptedPacket = pack('C', 0); //kAESNONE
+        $this->numFields = pack('N', $nfields);
+        $this->expandedSize = pack('N', 0);
+        $this->timeout = pack('N', $timeout);
+        $this->protocolVersion = pack('C', 4); //k2011PROTOCOL;
+        $this->clientType = pack('C', 0);
+        $this->reserved1 = pack('v', 0);
+        $this->reserved2 = pack('v', 0);
+    }
+}
+
+
+/**
+ * Class outhead
+ *
+ * server -> client header
+ */
+class outhead
+{
+    public $signature; //unsigned int					// PROTOCOL_SIGNATURE defined as 'SQLS'
+    public $packetSize; //unsigned int					// size of the entire packet (header excluded)
+    public $errorCode; //unsigned short					// 0 means no error
+    public $flag1; //unsigned char						// bit field
+    public $encryptedPacket; //unsigned char			// kEmptyField, kAESNONE, kAES128, kAES192, kAES256
+    public $expandedSize; //unsigned int				// if flag1 is COMPRESSED_PACKET this is the expanded size of the entire buffer
+    public $rows; //unsigned int						// number of rows in the cursor
+    public $cols; //unsigned int						// number of columns in the cursor (it could be 2 bytes instead of 4?)
+    public $numFields; //unsigned int					// number of fields in the command (I could use 2 bytes instead of 4)
+    public $reserved1; //unsigned short					// unused in this version
+    public $reserved2; //unsigned short					// unused in this version
+
+    function __construct($bytes)
+    {
+        $this->signature = substr($bytes, 0, 4);
+        $this->packetSize = unpack("NpacketSize", substr($bytes, 4, 4))["packetSize"];
+        $this->errorCode = unpack("nerrorCode", substr($bytes, 8, 2))["errorCode"];
+        $this->flag1 = ord(substr($bytes, 10, 1));
+        $this->encryptedPacket = ord(substr($bytes, 11, 1));
+        $this->expandedSize = unpack("NexpandedSize", substr($bytes, 12, 4))["expandedSize"];
+        $this->rows = unpack("Nrows", substr($bytes, 16, 4))["rows"];
+        $this->cols = unpack("Ncols", substr($bytes, 20, 4))["cols"];
+        $this->numFields = unpack("NnumFields", substr($bytes, 24, 4))["numFields"];
+        $this->reserved1 = unpack("nreserved1", substr($bytes, 28, 2))["reserved1"];
+        $this->reserved2 = unpack("nreserved2", substr($bytes, 30, 2))["reserved2"];
+    }
+}
+
+
+/**
+ * Class csqldb
+ *
+ * @author Marco Bambini <marco@sqlabs.com>
+ */
+class csqldb
+{
+    public $timeout; // timeout used in the socket I/O operations
+    public $sockfd; // the socket
+    public $port; // port used for the connection
+    public $host; // hostname
+    public $username; // username
+    public $password; // password
+    public $errmsg; // last error message
+    public $errcode; // last error code
+//	public $useOldProtocol;	// flag to set if you want to use the old REALSQLServer protocol
+    public $verifyPeer; // flag to check if peer verification must be performed
+
 //	char			*token;						// optional token used in token connect
 //	char			*hostverification;			// optional host verification name to use in SSL peer verification
 //	void			*userptr;					// optional pointer saved by the user
@@ -107,542 +135,582 @@ class csqldb {
 //	aes_encrypt_ctx	encryptkey[1];				// session key used to encrypt data
 //	aes_decrypt_ctx decryptkey[1];				// session key used to decrypt data
 
-	public $toread;
-	public $inbuffer;
-	public $insize;
-	
-	public $request; //inhead					// request header
-	public $reply; //outhead						// response header
-	
-	//SSL_CTX			*ssl_ctx;
-	//SSL				*ssl;
-	
-	//void (*trace)  (const char*, void*);		// trace function
-	//void			*traceArgument;				// user argument to be passed to the trace function
-	public function __construct($host, $port, $username, $password, $timeout) {
-		$this->host = $host;
-		$this->port = $port;
-		$this->username = $username;
-		$this->password = $password;
-		$this->timeout = $timeout;
+    public $toread;
+    public $inbuffer;
+    public $insize;
+    public $request; //inhead // request header
+    public $reply; //outhead // response header
 
-		//connect
-		$addr = gethostbyname($this->host); //no way to specify a timeout
-		$this->socketfd = stream_socket_client("tcp://$addr:".$this->port, $this->errcode, $this->errormsg, $this->timeout);
+    //SSL_CTX			*ssl_ctx;
+    //SSL				*ssl;
 
-		if ($this->socketfd === false) {
-			$this->errorcode = -1;
-			$this->errormsg = "Failed to connect: '".$this->errormsg."'";
-			throw new UnexpectedValueException("Failed to connect: '".$this->errormsg."'");
-		}
-		$nfields = 1;
-		$sizeof_int = 4;
-		$nsizedim = $sizeof_int * $nfields;
-		$SHA1_DIGEST_SIZE = 20;
-		$datasize = $SHA1_DIGEST_SIZE*2+1;
-		$packet_size = $datasize + $nsizedim;
-		$kCOMMAND_CONNECT = 1;
-		$kCLEAR_CONNECT_PHASE1 = 20;
-		$this->request = new inhead($packet_size, $nfields, $kCOMMAND_CONNECT, $kCLEAR_CONNECT_PHASE1,$this->timeout);
-		$field_size = pack('N',$datasize);
-		$this->netwrite($field_size,sha1($this->username).chr(0));
+    //void (*trace)  (const char*, void*);		// trace function
+    //void			*traceArgument;				// user argument to be passed to the trace function
+    public function __construct($host, $port, $username, $password, $timeout)
+    {
+        $this->host = $host;
+        $this->port = $port;
+        $this->username = $username;
+        $this->password = $password;
+        $this->timeout = $timeout;
 
-	// read random pool
-		
-		$kRANDPOOLSIZE = 20;
-		$this->netread($kRANDPOOLSIZE, 1);
-		$randpool = $this->inbuffer;
+        //connect
+        $addr = gethostbyname($this->host); //no way to specify a timeout
+        $this->socketfd = stream_socket_client("tcp://$addr:" . $this->port, $this->errcode, $this->errormsg, $this->timeout);
 
-		$nfields = 1;
-		$sizeof_int = 4;
-		$nsizedim = $sizeof_int * $nfields;
-		$datasize = $SHA1_DIGEST_SIZE;
-	
-	// build packet
-		$packet_size = $datasize + $nsizedim;
-		$kCLEAR_CONNECT_PHASE2 = 21;
-		$this->request = new inhead($packet_size, $nfields, $kCOMMAND_CONNECT, $kCLEAR_CONNECT_PHASE2,$this->timeout);
-		$field_size = pack('N',$SHA1_DIGEST_SIZE);
-		$this->netwrite($field_size,sha1($randpool.sha1(sha1($this->password,true),true),true));
-	// read header reply and sanity check it
-		$this->netread(0, 0);
-	}
-	function disconnect() {
-		$kCOMMAND_CLOSE = 7;
-		$kNO_SELECTOR = 0;
-		$this->request = new inhead(0, 0, $kCOMMAND_CLOSE, $kNO_SELECTOR,$this->timeout);
-		fwrite($this->socketfd,$this->request->to_bytes());
-		$this->netread(-1, -1);
-	}
-	function checkheader($expected_size, $expected_nfields) {
-		/***************************************************************
-		echo "packetSize: ".$this->reply->packetSize."\n";
-		echo "errorCode: ".$this->reply->errorCode."\n";
-		echo "flag1: ".$this->reply->flag1."\n";
-		echo "encryptedPacket: ".$this->reply->encryptedPacket."\n";
-		echo "expandedSize: ".$this->reply->expandedSize."\n";
-		echo "rows: ".$this->reply->rows."\n";
-		echo "cols: ".$this->reply->cols."\n";
-		echo "numFields: ".$this->reply->numFields."\n";
-		echo "reserved1: ".$this->reply->reserved1."\n";
-		echo "reserved2: ".$this->reply->reserved2."\n";
-		***************************************************************/
-		if($this->reply->signature!="SQLS") {
-			$this->errormsg = "Wrong SIGNATURE HEADER from the server";
-			$this->errorcode = -1;
-			throw new UnexpectedValueException("Wrong SIGNATURE HEADER from the server");
-		}
-		$is_end_chunk = false;
-		$END_CHUNK = 777;
-		if($this->reply->errorCode==$END_CHUNK) {
-			$is_end_chunk = true;
-			$err = 0;
-		} else {
-			$err = $this->reply->errorCode;
-		}
-		if($err) {
-			$this->toread = 0;
-			$bytes = $this->socket_read($this->reply->packetSize);
-			$this->errorcode = $err;
-			$this->errormsg = "Error from server: '$bytes'";
-			throw new UnexpectedValueException("Error from server: '$bytes'");
+        if ($this->socketfd === false) {
+            $this->errorcode = -1;
+            $this->errormsg = "Failed to connect: '" . $this->errormsg . "'";
+            throw new UnexpectedValueException("Failed to connect: '" . $this->errormsg . "'");
+        }
+        $nfields = 1;
+        $sizeof_int = 4;
+        $nsizedim = $sizeof_int * $nfields;
+        $SHA1_DIGEST_SIZE = 20;
+        $datasize = $SHA1_DIGEST_SIZE * 2 + 1;
+        $packet_size = $datasize + $nsizedim;
+        $kCOMMAND_CONNECT = 1;
+        $kCLEAR_CONNECT_PHASE1 = 20;
+        $this->request = new inhead($packet_size, $nfields, $kCOMMAND_CONNECT, $kCLEAR_CONNECT_PHASE1, $this->timeout);
+        $field_size = pack('N', $datasize);
+        $this->netwrite($field_size, sha1($this->username) . chr(0));
 
-		} else {
-			$this->toread = $this->reply->packetSize;
-		}
+        // read random pool
+        $kRANDPOOLSIZE = 20;
+        $this->netread($kRANDPOOLSIZE, 1);
+        $randpool = $this->inbuffer;
 
-		if($expected_size!=-1 && $expected_size!=$this->reply->packetSize) {
-			$this->errorcode = -1;
-			$this->errormsg = "Wrong PACKET SIZE received from the server";
-			throw new UnexpectedValueException("Wrong PACKET SIZE received from the server");
-		}
+        $nfields = 1;
+        $sizeof_int = 4;
+        $nsizedim = $sizeof_int * $nfields;
+        $datasize = $SHA1_DIGEST_SIZE;
 
-		if($expected_nfields!=-1 && $expected_nfields!=$this->reply->numFields) {
-			$this->errorcode = -1;
-			$this->errormsg = "Wrong NUMBER OF FIELDS received from the server";
-			throw new UnexpectedValueException("Wrong NUMBER OF FIELDS received from the server");
-		}
-		return $is_end_chunk;
-		
-	}
-	function send_statement($command_type, $sql) {
-		$nfields = 1;
-		$sizeof_int = 4;
-		$nsizedim = $sizeof_int * $nfields;
-		$datasize = strlen($sql) + 1;
-	
-	// build packet
-		$packet_size = $datasize + $nsizedim;
-		$kNO_SELECTOR = 0;
-		$this->request = new inhead($packet_size, $nfields, $command_type, $kNO_SELECTOR,$this->timeout);
-		$field_size = pack('N',$datasize);
-		$this->netwrite($field_size, $sql.chr(0));
+        // build packet
+        $packet_size = $datasize + $nsizedim;
+        $kCLEAR_CONNECT_PHASE2 = 21;
+        $this->request = new inhead($packet_size, $nfields, $kCOMMAND_CONNECT, $kCLEAR_CONNECT_PHASE2, $this->timeout);
+        $field_size = pack('N', $SHA1_DIGEST_SIZE);
+        $this->netwrite($field_size, sha1($randpool . sha1(sha1($this->password, true), true), true));
+        // read header reply and sanity check it
+        $this->netread(0, 0);
+    }
 
-	}
-	function netwrite($size_array, $buffer) {
-		fwrite($this->socketfd,$this->request->to_bytes());
-		fwrite($this->socketfd,$size_array);
-		fwrite($this->socketfd,$buffer);
-	}
-	function socket_read($expected_size) {
-		$bytes = "";
-		$start = time();
-		while(strlen($bytes)<$expected_size) {
-			if(time()-$start>$this->timeout) {
-				$this->errorcode = -1;
-				$this->errormsg = "Timeout while reading from network socket.";
-				throw new UnexpectedValueException("Timeout while reading from network socket.");
-			}
-			$bytes .= fread($this->socketfd,$expected_size-strlen($bytes));
-		}
-		return $bytes;
-		
-	}
-	function netread($expected_size, $expected_nfields) {
-		$kHEADER_SIZE = 32;
-		$bytes = $this->socket_read($kHEADER_SIZE);
-		/***************************************************************
-		echo "netread: ";
-		for($j=0;$j<strlen($bytes);$j++) {
-			echo sprintf("%02x ",ord($bytes[$j]));
-		}
-		echo "\n";
-		***************************************************************/
-		$this->reply = new outhead($bytes);
-		$is_end_chunk = $this->checkheader($expected_size, $expected_nfields);
-		if($is_end_chunk) return true;
-		if($this->toread>0) {
-			$this->inbuffer = $this->socket_read($this->toread);
-		}
-		$kAESNONE = 0;
-		if($this->reply->encryptedPacket != $kAESNONE) {
-			$this->errorcode = -1;
-			$this->errormsg = "Server sent an encrypted packet.";
-			throw new UnexpectedValueException("Server sent an encrypted packet.");
-		}
-		$SERVER_COMPRESSED_PACKET = 0x08;
-		if($this->reply->flag1 & $SERVER_COMPRESSED_PACKET) {
-			$this->inbuffer = gzuncompress($this->inbuffer);
-		}
-		
-		return $is_end_chunk;
-	}
-	function parse_packet(&$server_types,&$col_names) {
-		
-		$nfields = $this->reply->numFields;
-		$server_rowcount = $this->reply->rows;
-		$nrows = $this->reply->rows;
-		
-		//$SERVER_PARTIAL_PACKET = 0x20;
-		//print "read_cursor() !is_end_chunk: ".!$is_end_chunk."\n";
-		//print "(this->reply->flag1 & SERVER_PARTIAL_PACKET): ".!!(($this->reply->flag1 & $SERVER_PARTIAL_PACKET))."\n";
-		//print "read_cursor() nrows: $nrows\n";
+    function disconnect()
+    {
+        $kCOMMAND_CLOSE = 7;
+        $kNO_SELECTOR = 0;
+        $this->request = new inhead(0, 0, $kCOMMAND_CLOSE, $kNO_SELECTOR, $this->timeout);
+        fwrite($this->socketfd, $this->request->to_bytes());
+        $this->netread(-1, -1);
+    }
 
-		$server_colcount = $this->reply->cols;
-		$SERVER_HAS_ROWID_COLUMN = 0x04;
-		if($this->reply->flag1 & $SERVER_HAS_ROWID_COLUMN) {
-			$has_rowid = true;
-			$ncols = $this->reply->cols-1;
-		} else {
-			$has_rowid = false;
-			$ncols = $this->reply->cols;
-		}
-		$SERVER_HAS_TABLE_NAME = 0x80;
-		if($this->reply->flag1 & $SERVER_HAS_TABLE_NAME) {
-			$has_tables = true;
-		} else {
-			$has_tables = false;
-		}
-		
-		$sizeof_int = 4;
-		if(count($server_types)==0) {
-			$server_sizes = $sizeof_int * $server_colcount;
-			for($j=0; $j < $server_colcount; $j++) {
-				$type = unpack("Ntype",substr($this->inbuffer,$j*$sizeof_int,4))["type"];
-					//echo "type $j: $type\n";
-			}
-			$server_names = $server_sizes + ($server_rowcount * $server_colcount * $sizeof_int);
-			$server_data = $server_names;
-			$temp = $server_names;
-			$data_seek = 0;
-			for($j=0; $j < $server_colcount; $j++) {
-				$len = strpos($this->inbuffer,0,$temp)-$temp+1;
-				$col_names[$j] = substr($this->inbuffer,$temp,$len-1);
-				$data_seek += $len;
-				$temp += $len;
-				$server_types[$j] = unpack("Ntype",substr($this->inbuffer,$j*$sizeof_int,4))["type"];
-			}
-			$table_names = array();
-			if($has_tables) {
-				$server_tables = $server_data + $data_seek;
-				$temp = $server_tables;
-				for($j=0; $j < $server_colcount; $j++) {
-					$len = strpos($this->inbuffer,0,$temp)-$temp+1;
-					$table_names[$j] = substr($this->inbuffer,$temp,$len-1);
-					$data_seek += $len;
-					$temp += $len;
-				}
-			}
-			$server_data += $data_seek;
-			$after_sizes_if_exist = $sizeof_int*$server_colcount;
-		} else {
-			$server_data = $sizeof_int*$server_colcount*$nrows;
-			$after_sizes_if_exist = 0;
-		}
-		$count = $server_colcount * $server_rowcount;
-		$server_sizes = array();
-		$server_sum = array();
-		for ($j=0; $j < $count; $j++) {
-			$pos = $after_sizes_if_exist + $j*$sizeof_int;
-			if($pos+4>=strlen($this->inbuffer)) {
-				throw new UnexpectedValueException("Buffer from server too short.");
-			}
-			$server_sizes[$j] = unpack("lsize",strrev(substr($this->inbuffer,$pos,4)))["size"];
-			if ($server_sizes[$j] == -1)
-			//if ($server_sizes[$j] == 4294967295)  //interesting side-effect of unpack not returning -1 for a value of FF FF FF FF.
-			{
-				$server_sizes[$j] = -1;
-				// special NULL case
-				if ($j == 0)
-				{
-					$server_sum[$j] = 0;
-				} 
-				else
-				{
-					$server_sum[$j] = $server_sum[$j-1];
-				}
-			} 
-			else 
-			{
-				if ($j == 0)
-				{
-					$server_sum[$j] = $server_sizes[$j];
-				}
-				else 
-				{
-					$server_sum[$j] = $server_sizes[$j] + $server_sum[$j-1];
-				}
-			}
-		}
-		$data = array();
-		$j = 0;
-		for($row=0;$row<$nrows;$row++) {
-			$rowdata = array();
-			for($col=0;$col<$server_colcount;$col++) {
-				$len = $server_sizes[$j];
-				if($j==0) {
-					$pos = $server_data;
-				} else {
-					$pos = $server_data + $server_sum[$j-1];
-				}
-				if(!($has_rowid && $col==0)) {
-					if($server_sizes[$j]==-1) {
-						$val = NULL;
-					} else {
-						//syslog(1, "pulling out $len characters from inbuffer starting from ". $pos);
-						$str = substr($this->inbuffer,$pos,$len);
-						//syslog(1, "pulled out: " . $str);
-						$type = $server_types[$col];
-						switch($type) {
-							case 0: //None
-								$val = $str;
-								break;
-							case 1: //Integer
-								$val = intval($str);
-								break;
-							case 2: //Float
-								$val = floatval($str);
-								break;
-							case 3: //REAL or TEXT (maybe should be UTF-8???)
-								$val = $str;
-								break;
-							case 4: //BLOB (definitely not UTF-8)
-								$val = $str;
-								break;
-							case 5: //None
-								$val = boolval($str);
-								break;
-							case 6: //Date
-								$val = $str;
-								break;
-							case 7: //Time
-								$val = $str;
-								break;
-							case 8: //Timestamp
-								$val = $str;
-								break;
-							case 9: //Currency
-								$val = floatval($str);
-								break;
-							default:
-								syslog(1, "unknown type: $type, for data: '$str'\n");
-								$val = $str;
-						}
-					}
-					$rowdata[$col_names[$col]] = $val;
-				}
-				$j++;
-			}
-			$data[$row] = $rowdata;
-		}
-		//echo "nrows: $nrows, ncols: $ncols\n";
-		//var_dump($table_names); //if $has_rowid, the first table_name can be dropped
-		//var_dump($col_names); //if $has_rowid, the first col_name can be dropped
-		//var_dump($server_types); //if $has_rowid, the first server_type can be dropped
-		//syslog(1,"*#$*#$*#*$:parse_packet::complete.");
-		
-		return $data;
+    function checkheader($expected_size, $expected_nfields)
+    {
+        /***************************************************************
+         * echo "packetSize: ".$this->reply->packetSize."\n";
+         * echo "errorCode: ".$this->reply->errorCode."\n";
+         * echo "flag1: ".$this->reply->flag1."\n";
+         * echo "encryptedPacket: ".$this->reply->encryptedPacket."\n";
+         * echo "expandedSize: ".$this->reply->expandedSize."\n";
+         * echo "rows: ".$this->reply->rows."\n";
+         * echo "cols: ".$this->reply->cols."\n";
+         * echo "numFields: ".$this->reply->numFields."\n";
+         * echo "reserved1: ".$this->reply->reserved1."\n";
+         * echo "reserved2: ".$this->reply->reserved2."\n";
+         ***************************************************************/
+        if ($this->reply->signature != "SQLS") {
+            $this->errormsg = "Wrong SIGNATURE HEADER from the server";
+            $this->errorcode = -1;
+            throw new UnexpectedValueException("Wrong SIGNATURE HEADER from the server");
+        }
+        $is_end_chunk = false;
+        $END_CHUNK = 777;
+        if ($this->reply->errorCode == $END_CHUNK) {
+            $is_end_chunk = true;
+            $err = 0;
+        } else {
+            $err = $this->reply->errorCode;
+        }
+        if ($err) {
+            $this->toread = 0;
+            $bytes = $this->socket_read($this->reply->packetSize);
+            $this->errorcode = $err;
+            $this->errormsg = "Error from server: '$bytes'";
+            throw new UnexpectedValueException("Error from server: '$bytes'");
 
-	}
-	function read_cursor() {
-		//print "---------\n";
-		//print "read_cursor()\n";
-		$is_end_chunk = $this->netread(-1,-1);
-		$server_types = array();
-		$col_names = array();
-		$data = $this->parse_packet($server_types,$col_names);
-		//echo "server_types: ";
-		//print_r($server_types);
-		//echo "\n";
-		//echo "col_names: ";
-		//print_r($col_names);
-		//echo "\n";
-		//syslog(1, "read_cursor::first packet: " . var_export($data, true));
-		$SERVER_PARTIAL_PACKET = 0x20;
+        } else {
+            $this->toread = $this->reply->packetSize;
+        }
 
-		while(!$is_end_chunk && ($this->reply->flag1 & $SERVER_PARTIAL_PACKET)) {
-			$kCHUNK_OK = 25;
-			$this->ack($kCHUNK_OK);
-			$is_end_chunk = $this->netread(-1,-1);
-			if(!$is_end_chunk) {
-				//$inbuffer .= $this->inbuffer;
-				//$nrows += $this->reply->rows;
-				//print "read_cursor() ";
-				//print $this->reply->rows;
-				//print " more rows\n";
-				//syslog(1, "read_cursor:: reading another row....");
-				$newData = $this->parse_packet($server_types,$col_names);
-				//syslog(1, "read_cursor:: new row data: " . var_export($newData, true));
-				$data = array_merge($data,$newData);
-				//syslog(1, "read_cursor::merged new data.  Now have: " . var_export($data, true));
-				//syslog(1, "=---------=");
-			}
-		}
-		return $data;
+        if ($expected_size != -1 && $expected_size != $this->reply->packetSize) {
+            $this->errorcode = -1;
+            $this->errormsg = "Wrong PACKET SIZE received from the server";
+            throw new UnexpectedValueException("Wrong PACKET SIZE received from the server");
+        }
 
-	}
-	function ack($chunk_code) {
-		//if ($chunk_code == $kCOMMAND_ENDCHUNK) {
-		//	initrequest(db, 0, 0, kCOMMAND_ENDCHUNK, kNO_SELECTOR);
-		//	csql_netwrite(db, NULL, 0, NULL, 0);
-		//	return csql_netread(db, -1, -1, kFALSE, NULL, NO_TIMEOUT);
-		//}
-		//
-		//if ((chunk_code == kBIND_FINALIZE) || (chunk_code == kBIND_ABORT)) {
-		//	initrequest(db, 0, 0, kCOMMAND_CHUNK_BIND, chunk_code);
-		//	csql_netwrite(db, NULL, 0, NULL, 0);
-		//	return csql_netread(db, -1, -1, kFALSE, NULL, NO_TIMEOUT);
-		//}
-		$kCOMMAND_ENDCHUNK = 10;
-		$kBIND_FINALIZE = 28;
-		$kBIND_ABORT = 29;
-		if($chunk_code==$kCOMMAND_ENDCHUNK ||
-		   $chunk_code==$kBIND_FINALIZE ||
-		   $chunk_code==$kBIND_ABORT) {
-			throw new UnexpectedValueException("ack called with unexpected chunk_code value.");
-		}
-		// other cases
-		$packet_size = 0;
-		$nfields = 0;
-		$kCOMMAND_CHUNK = 9;
-		$this->request = new inhead($packet_size, $nfields, $kCOMMAND_CHUNK, $chunk_code, $this->timeout);
-//function netwrite($size_array, $buffer)
-//int csql_netwrite (csqldb *db, char *size_array, int nsize_array, char *buffer, int nbuffer)
-		return $this->netwrite('', '');
-	}
+        if ($expected_nfields != -1 && $expected_nfields != $this->reply->numFields) {
+            $this->errorcode = -1;
+            $this->errormsg = "Wrong NUMBER OF FIELDS received from the server";
+            throw new UnexpectedValueException("Wrong NUMBER OF FIELDS received from the server");
+        }
+        return $is_end_chunk;
 
-};
-	class cubeSQLServer
-	{
-		public $db;
-	    public $errorCode;
-    	public $errorMessage;
-    	
-    	/**
-    	 Connect to CubeSQL instance on host, port, using username, password, allowing up to timeout for connection to occur.
-    	 Sets internal error indicators errorCode and errorMessage on error
-    	 returns boolean (true on success, false on failure)
-    	**/
-    	public function connect($host, $port, $username, $password, $timeout = 12) 
-    	{
-    		$this->_resetError();
+    }
 
-		try {
-    		$this->db = new csqldb($host, $port, $username, $password, $timeout);
-    		} catch(Exception $e) {
-			$this->errorCode = $this->db->errcode;
-			$this->errorMessage = $this->db->errmsg;
-			syslog(1,$e);
-		}
-    		
-    		return !$this->isError();
-    	}
-    	
-    	/**
-    	 Connect to CubeSQL instance on host, port, using username, password, allowing up to timeout for connection to occur.
-    	 Once connection is successful, select database to use
-    	 Sets internal error indicators errorCode and errorMessage on error
-    	 returns boolean (true on success, false on failure)
-    	**/
-    	public function connect_database($host, $port, $username, $password, $database, $timeout = 12) 
-    	{
-    		$this->_resetError();
-		try {
-    			$this->db = new csqldb($host, $port, $username, $password, $timeout);
-			$kCOMMAND_EXECUTE = 3;
-	    		$this->db->send_statement($kCOMMAND_EXECUTE, "USE DATABASE $database;");
-			$this->db->netread(-1,-1);
-    		} catch(Exception $e) {
-			$this->errorCode = $this->db->errcode;
-			$this->errorMessage = $this->db->errmsg;
-			syslog(1, "Database connection error: " . $this->errorMessage);
-			//echo $e;
-		}
-    					
-    		return !$this->isError();
-    	}
-    	
-    	/**
-    	 Execute given SQL statement on the server I'm currently connected to.
-    	 Sets internal error indicators errorCode and errorMessage on error
-    	 returns void
-    	**/
-    	public function execute($sql) 
-    	{
-    		$this->_resetError();
-		try {
-			$kCOMMAND_EXECUTE = 3;
-	    		$this->db->send_statement($kCOMMAND_EXECUTE, $sql);
-			$this->db->netread(-1,-1);
-    		} catch(Exception $e) {
-				$this->errorCode = $this->db->errcode;
-				$this->errorMessage = $this->db->errmsg;
-				syslog(1,$e);
-				syslog(1, $this->errorCode);
-				syslog(1, $this->errorMessage);
-			}
-    	}
-    	
-    	/**
-    	 Execute given SQL select query on the server I'm currently connected to.
-    	 Sets internal error indicators errorCode and errorMessage on error
-    	 returns 2D associative array of results.
-    	**/
-    	public function select($sql) 
-    	{
+    /**
+     * @param int    $command_type
+     * @param string $sql
+     */
+    function send_statement($command_type, $sql)
+    {
+        $nfields = 1;
+        $sizeof_int = 4;
+        $nsizedim = $sizeof_int * $nfields;
+        $datasize = strlen($sql) + 1;
+
+        // build packet
+        $packet_size = $datasize + $nsizedim;
+        $kNO_SELECTOR = 0;
+        $this->request = new inhead($packet_size, $nfields, $command_type, $kNO_SELECTOR, $this->timeout);
+        $field_size = pack('N', $datasize);
+        $this->netwrite($field_size, $sql . chr(0));
+    }
+
+    function netwrite($size_array, $buffer)
+    {
+        fwrite($this->socketfd, $this->request->to_bytes());
+        fwrite($this->socketfd, $size_array);
+        fwrite($this->socketfd, $buffer);
+    }
+
+    function socket_read($expected_size)
+    {
+        $bytes = "";
+        $start = time();
+        while (strlen($bytes) < $expected_size) {
+            if (time() - $start > $this->timeout) {
+                $this->errorcode = -1;
+                $this->errormsg = "Timeout while reading from network socket.";
+                throw new UnexpectedValueException("Timeout while reading from network socket.");
+            }
+            $bytes .= fread($this->socketfd, $expected_size - strlen($bytes));
+        }
+        return $bytes;
+
+    }
+
+    function netread($expected_size, $expected_nfields)
+    {
+        $kHEADER_SIZE = 32;
+        $bytes = $this->socket_read($kHEADER_SIZE);
+        /***************************************************************
+         * echo "netread: ";
+         * for($j=0;$j<strlen($bytes);$j++) {
+         * echo sprintf("%02x ",ord($bytes[$j]));
+         * }
+         * echo "\n";
+         ***************************************************************/
+        $this->reply = new outhead($bytes);
+        $is_end_chunk = $this->checkheader($expected_size, $expected_nfields);
+        if ($is_end_chunk) return true;
+        if ($this->toread > 0) {
+            $this->inbuffer = $this->socket_read($this->toread);
+        }
+        $kAESNONE = 0;
+        if ($this->reply->encryptedPacket != $kAESNONE) {
+            $this->errorcode = -1;
+            $this->errormsg = "Server sent an encrypted packet.";
+            throw new UnexpectedValueException("Server sent an encrypted packet.");
+        }
+        $SERVER_COMPRESSED_PACKET = 0x08;
+        if ($this->reply->flag1 & $SERVER_COMPRESSED_PACKET) {
+            $this->inbuffer = gzuncompress($this->inbuffer);
+        }
+
+        return $is_end_chunk;
+    }
+
+    function parse_packet(&$server_types, &$col_names)
+    {
+        $nfields = $this->reply->numFields;
+        $server_rowcount = $this->reply->rows;
+        $nrows = $this->reply->rows;
+
+        //$SERVER_PARTIAL_PACKET = 0x20;
+        //print "read_cursor() !is_end_chunk: ".!$is_end_chunk."\n";
+        //print "(this->reply->flag1 & SERVER_PARTIAL_PACKET): ".!!(($this->reply->flag1 & $SERVER_PARTIAL_PACKET))."\n";
+        //print "read_cursor() nrows: $nrows\n";
+
+        $server_colcount = $this->reply->cols;
+        $SERVER_HAS_ROWID_COLUMN = 0x04;
+        if ($this->reply->flag1 & $SERVER_HAS_ROWID_COLUMN) {
+            $has_rowid = true;
+            $ncols = $this->reply->cols - 1;
+        } else {
+            $has_rowid = false;
+            $ncols = $this->reply->cols;
+        }
+        $SERVER_HAS_TABLE_NAME = 0x80;
+        if ($this->reply->flag1 & $SERVER_HAS_TABLE_NAME) {
+            $has_tables = true;
+        } else {
+            $has_tables = false;
+        }
+
+        $sizeof_int = 4;
+        if (count($server_types) == 0) {
+            $server_sizes = $sizeof_int * $server_colcount;
+            for ($j = 0; $j < $server_colcount; $j++) {
+                $type = unpack("Ntype", substr($this->inbuffer, $j * $sizeof_int, 4))["type"];
+                //echo "type $j: $type\n";
+            }
+            $server_names = $server_sizes + ($server_rowcount * $server_colcount * $sizeof_int);
+            $server_data = $server_names;
+            $temp = $server_names;
+            $data_seek = 0;
+            for ($j = 0; $j < $server_colcount; $j++) {
+                $len = strpos($this->inbuffer, 0, $temp) - $temp + 1;
+                $col_names[$j] = substr($this->inbuffer, $temp, $len - 1);
+                $data_seek += $len;
+                $temp += $len;
+                $server_types[$j] = unpack("Ntype", substr($this->inbuffer, $j * $sizeof_int, 4))["type"];
+            }
+            $table_names = array();
+            if ($has_tables) {
+                $server_tables = $server_data + $data_seek;
+                $temp = $server_tables;
+                for ($j = 0; $j < $server_colcount; $j++) {
+                    $len = strpos($this->inbuffer, 0, $temp) - $temp + 1;
+                    $table_names[$j] = substr($this->inbuffer, $temp, $len - 1);
+                    $data_seek += $len;
+                    $temp += $len;
+                }
+            }
+            $server_data += $data_seek;
+            $after_sizes_if_exist = $sizeof_int * $server_colcount;
+        } else {
+            $server_data = $sizeof_int * $server_colcount * $nrows;
+            $after_sizes_if_exist = 0;
+        }
+        $count = $server_colcount * $server_rowcount;
+        $server_sizes = array();
+        $server_sum = array();
+        for ($j = 0; $j < $count; $j++) {
+            $pos = $after_sizes_if_exist + $j * $sizeof_int;
+            if ($pos + 4 >= strlen($this->inbuffer)) {
+                throw new UnexpectedValueException("Buffer from server too short.");
+            }
+            $server_sizes[$j] = unpack("lsize", strrev(substr($this->inbuffer, $pos, 4)))["size"];
+            if ($server_sizes[$j] == -1) //if ($server_sizes[$j] == 4294967295)  //interesting side-effect of unpack not returning -1 for a value of FF FF FF FF.
+            {
+                $server_sizes[$j] = -1;
+                // special NULL case
+                if ($j == 0) {
+                    $server_sum[$j] = 0;
+                } else {
+                    $server_sum[$j] = $server_sum[$j - 1];
+                }
+            } else {
+                if ($j == 0) {
+                    $server_sum[$j] = $server_sizes[$j];
+                } else {
+                    $server_sum[$j] = $server_sizes[$j] + $server_sum[$j - 1];
+                }
+            }
+        }
+        $data = array();
+        $j = 0;
+        for ($row = 0; $row < $nrows; $row++) {
+            $rowdata = array();
+            for ($col = 0; $col < $server_colcount; $col++) {
+                $len = $server_sizes[$j];
+                if ($j == 0) {
+                    $pos = $server_data;
+                } else {
+                    $pos = $server_data + $server_sum[$j - 1];
+                }
+                if (!($has_rowid && $col == 0)) {
+                    if ($server_sizes[$j] == -1) {
+                        $val = NULL;
+                    } else {
+                        //syslog(1, "pulling out $len characters from inbuffer starting from ". $pos);
+                        $str = substr($this->inbuffer, $pos, $len);
+                        //syslog(1, "pulled out: " . $str);
+                        $type = $server_types[$col];
+                        switch ($type) {
+                            case 0: //None
+                                $val = $str;
+                                break;
+                            case 1: //Integer
+                                $val = intval($str);
+                                break;
+                            case 2: //Float
+                                $val = floatval($str);
+                                break;
+                            case 3: //REAL or TEXT (maybe should be UTF-8???)
+                                $val = $str;
+                                break;
+                            case 4: //BLOB (definitely not UTF-8)
+                                $val = $str;
+                                break;
+                            case 5: //None
+                                $val = boolval($str);
+                                break;
+                            case 6: //Date
+                                $val = $str;
+                                break;
+                            case 7: //Time
+                                $val = $str;
+                                break;
+                            case 8: //Timestamp
+                                $val = $str;
+                                break;
+                            case 9: //Currency
+                                $val = floatval($str);
+                                break;
+                            default:
+                                syslog(1, "unknown type: $type, for data: '$str'\n");
+                                $val = $str;
+                        }
+                    }
+                    $rowdata[$col_names[$col]] = $val;
+                }
+                $j++;
+            }
+            $data[$row] = $rowdata;
+        }
+        //echo "nrows: $nrows, ncols: $ncols\n";
+        //var_dump($table_names); //if $has_rowid, the first table_name can be dropped
+        //var_dump($col_names); //if $has_rowid, the first col_name can be dropped
+        //var_dump($server_types); //if $has_rowid, the first server_type can be dropped
+        //syslog(1,"*#$*#$*#*$:parse_packet::complete.");
+
+        return $data;
+    }
+
+    function read_cursor()
+    {
+        //print "---------\n";
+        //print "read_cursor()\n";
+        $is_end_chunk = $this->netread(-1, -1);
+        $server_types = array();
+        $col_names = array();
+        $data = $this->parse_packet($server_types, $col_names);
+        //echo "server_types: ";
+        //print_r($server_types);
+        //echo "\n";
+        //echo "col_names: ";
+        //print_r($col_names);
+        //echo "\n";
+        //syslog(1, "read_cursor::first packet: " . var_export($data, true));
+        $SERVER_PARTIAL_PACKET = 0x20;
+
+        while (!$is_end_chunk && ($this->reply->flag1 & $SERVER_PARTIAL_PACKET)) {
+            $kCHUNK_OK = 25;
+            $this->ack($kCHUNK_OK);
+            $is_end_chunk = $this->netread(-1, -1);
+            if (!$is_end_chunk) {
+                //$inbuffer .= $this->inbuffer;
+                //$nrows += $this->reply->rows;
+                //print "read_cursor() ";
+                //print $this->reply->rows;
+                //print " more rows\n";
+                //syslog(1, "read_cursor:: reading another row....");
+                $newData = $this->parse_packet($server_types, $col_names);
+                //syslog(1, "read_cursor:: new row data: " . var_export($newData, true));
+                $data = array_merge($data, $newData);
+                //syslog(1, "read_cursor::merged new data.  Now have: " . var_export($data, true));
+                //syslog(1, "=---------=");
+            }
+        }
+        return $data;
+    }
+
+    function ack($chunk_code)
+    {
+        //if ($chunk_code == $kCOMMAND_ENDCHUNK) {
+        //	initrequest(db, 0, 0, kCOMMAND_ENDCHUNK, kNO_SELECTOR);
+        //	csql_netwrite(db, NULL, 0, NULL, 0);
+        //	return csql_netread(db, -1, -1, kFALSE, NULL, NO_TIMEOUT);
+        //}
+        //
+        //if ((chunk_code == kBIND_FINALIZE) || (chunk_code == kBIND_ABORT)) {
+        //	initrequest(db, 0, 0, kCOMMAND_CHUNK_BIND, chunk_code);
+        //	csql_netwrite(db, NULL, 0, NULL, 0);
+        //	return csql_netread(db, -1, -1, kFALSE, NULL, NO_TIMEOUT);
+        //}
+        $kCOMMAND_ENDCHUNK = 10;
+        $kBIND_FINALIZE = 28;
+        $kBIND_ABORT = 29;
+        if ($chunk_code == $kCOMMAND_ENDCHUNK ||
+            $chunk_code == $kBIND_FINALIZE ||
+            $chunk_code == $kBIND_ABORT
+        ) {
+            throw new UnexpectedValueException("ack called with unexpected chunk_code value.");
+        }
+        // other cases
+        $packet_size = 0;
+        $nfields = 0;
+        $kCOMMAND_CHUNK = 9;
+        $this->request = new inhead($packet_size, $nfields, $kCOMMAND_CHUNK, $chunk_code, $this->timeout);
+        //function netwrite($size_array, $buffer)
+        //int csql_netwrite (csqldb *db, char *size_array, int nsize_array, char *buffer, int nbuffer)
+        return $this->netwrite('', '');
+    }
+
+}
+
+/**
+ * Class cubeSQLServer
+ *
+ * The cubeSQLServer is a class that allows to connect to a cubeSQL server open a database and send SQL statements or
+ * queries to that database. It returns the results for queries as an array. Errors that occur during this process are
+ * stored within the error properties of that object.
+ */
+class cubeSQLServer
+{
+    /** @var  csqldb object Stores the connection object. */
+    public $db;
+
+    /** @var  int Stores the error code. 0 means no error. */
+    public $errorCode;
+
+    /** @var  string Stores the error message. */
+    public $errorMessage;
+
+    /**
+     * Connect to CubeSQL instance
+     *
+     * On host and port using username and password. Allowing up to timeout for connection to
+     * occur. Sets internal error indicators errorCode and errorMessage on error. Returns boolean connection status.
+     *
+     * @param string $host     Hostname/IP of the cubeSQL Server
+     * @param int    $port     Port number of the cubeSQL Server
+     * @param string $username Username
+     * @param string $password Password
+     * @param int    $timeout  [optional] Time until the connection attempt fails. Default is 12 seconds.
+     * @return bool True on success, false on failure
+     */
+    public function connect($host, $port, $username, $password, $timeout = 12)
+    {
+        $this->_resetError();
+
+        try {
+            $this->db = new csqldb($host, $port, $username, $password, $timeout);
+        } catch (Exception $e) {
+            $this->errorCode = $this->db->errcode;
+            $this->errorMessage = $this->db->errmsg;
+            syslog(1, $e);
+        }
+
+        return !$this->isError();
+    }
+
+    /**
+     * Connect to CubeSQL instance and open a database
+     *
+     * On host and port using username and password and opens a database. Allowing up to timeout for connection to
+     * occur. Sets internal error indicators errorCode and errorMessage on error. Returns boolean connection status.
+     *
+     * @param string $host     Hostname/IP of the cubeSQL Server
+     * @param int    $port     Port number of the cubeSQL Server
+     * @param string $username Username
+     * @param string $password Password
+     * @param string $database Name of the database
+     * @param int    $timeout  [optional] Time until the connection attempt fails. Default is 12 seconds.
+     * @return bool True on success, false on failure
+     */
+    public function connect_database($host, $port, $username, $password, $database, $timeout = 12)
+    {
+        $this->_resetError();
+        try {
+            $this->db = new csqldb($host, $port, $username, $password, $timeout);
+            $kCOMMAND_EXECUTE = 3;
+            $this->db->send_statement($kCOMMAND_EXECUTE, "USE DATABASE $database;");
+            $this->db->netread(-1, -1);
+        } catch (Exception $e) {
+            $this->errorCode = $this->db->errcode;
+            $this->errorMessage = $this->db->errmsg;
+            syslog(1, "Database connection error: " . $this->errorMessage);
+            //echo $e;
+        }
+        return !$this->isError();
+    }
+
+    /**
+     * Execute given SQL statement on the server
+     *
+     * Uses current connection. Sets internal error indicators errorCode and errorMessage on error.
+     *
+     * @param string $sql
+     */
+    public function execute($sql)
+    {
+        $this->_resetError();
+        try {
+            $kCOMMAND_EXECUTE = 3;
+            $this->db->send_statement($kCOMMAND_EXECUTE, $sql);
+            $this->db->netread(-1, -1);
+        } catch (Exception $e) {
+            $this->errorCode = $this->db->errcode;
+            $this->errorMessage = $this->db->errmsg;
+            syslog(1, $e);
+            syslog(1, $this->errorCode);
+            syslog(1, $this->errorMessage);
+        }
+    }
+
+    /**
+     * Execute given SQL select query on the server
+     *
+     * Uses current connection. Sets internal error indicators errorCode and errorMessage on error.
+     *
+     * @param string $sql Select query statement.
+     * @return array 2D associative array of results.
+     */
+    public function select($sql)
+    {
         $this->_resetError();
         $kCOMMAND_SELECT = 2;
-    		$this->db->send_statement($kCOMMAND_SELECT, $sql);
-	    	$data = $this->db->read_cursor();
-    		
-    		// return associative array
-    		return $data;
-    	}
-    	
-    	/**
-    	 Disconnect from the currently connected CubeSQL server
-    	 Sets internal error indicators errorCode and errorMessage on error
-    	**/
-    	public function disconnect() 
-    	{
-    		$this->_resetError();
+        $this->db->send_statement($kCOMMAND_SELECT, $sql);
+        $data = $this->db->read_cursor();
+        return $data;
+    }
 
-		try {    		
-	    		$this->db->disconnect();
-    		} catch(Exception $e) {
-			$this->errorCode = $this->db->errcode;
-			$this->errorMessage = $this->db->errmsg;
-			syslog(1,$e);
-		}
-    	}
-    	
-    	/**
-    	 Convenience function to check for errors
-    	**/
-    	public function isError() 
-    	{
-    		if ($this->errorCode != 0) return true;
-    		return false;
-    	}
-    	
-    	/**
-    	 Convenience function to clear errors
-    	**/
-    	private function _resetError() 
-    	{
-    		$this->errorCode = 0;
-    		$this->errorMessage = "";
-    	}
-    	
-  }
-?>
+    /**
+     * Disconnect from the currently connected CubeSQL server
+     *
+     * Sets internal error indicators errorCode and errorMessage on error.
+     */
+    public function disconnect()
+    {
+        $this->_resetError();
+
+        try {
+            $this->db->disconnect();
+        } catch (Exception $e) {
+            $this->errorCode = $this->db->errcode;
+            $this->errorMessage = $this->db->errmsg;
+            syslog(1, $e);
+        }
+    }
+
+    /**
+     * Convenience function to check for errors
+     * @return bool
+     */
+    public function isError()
+    {
+        if ($this->errorCode != 0) return true;
+        return false;
+    }
+
+    /**
+     * Convenience function to clear errors
+     */
+    private function _resetError()
+    {
+        $this->errorCode = 0;
+        $this->errorMessage = "";
+    }
+}

--- a/PHP/Native/cubeSQLServer.php
+++ b/PHP/Native/cubeSQLServer.php
@@ -117,14 +117,30 @@ class outhead
  */
 class csqldb
 {
-    public $timeout; // timeout used in the socket I/O operations
-    public $sockfd; // the socket
-    public $port; // port used for the connection
-    public $host; // hostname
-    public $username; // username
-    public $password; // password
-    public $errmsg; // last error message
-    public $errcode; // last error code
+    /** @var  int Timeout used in the socket I/O operations */
+    public $timeout;
+
+    /** @var  mixed The socket */
+    public $sockfd;
+
+    /** @var  int Port used for the connection */
+    public $port;
+
+    /** @var  string Hostname */
+    public $host;
+
+    /** @var  string Username */
+    public $username;
+
+    /** @var  string Password */
+    public $password;
+
+    /** @var string Last error message */
+    public $errormsg;
+
+    /** @var int Last error code */
+    public $errorcode;
+
 //	public $useOldProtocol;	// flag to set if you want to use the old REALSQLServer protocol
     public $verifyPeer; // flag to check if peer verification must be performed
 
@@ -138,8 +154,12 @@ class csqldb
     public $toread;
     public $inbuffer;
     public $insize;
-    public $request; //inhead // request header
-    public $reply; //outhead // response header
+
+    /** @var inhead object Request Header */
+    public $request;
+
+    /** @var  outhead object Response Header */
+    public $reply;
 
     //SSL_CTX			*ssl_ctx;
     //SSL				*ssl;
@@ -156,7 +176,7 @@ class csqldb
 
         //connect
         $addr = gethostbyname($this->host); //no way to specify a timeout
-        $this->socketfd = stream_socket_client("tcp://$addr:" . $this->port, $this->errcode, $this->errormsg, $this->timeout);
+        $this->socketfd = stream_socket_client("tcp://$addr:" . $this->port, $this->errorcode, $this->errormsg, $this->timeout);
 
         if ($this->socketfd === false) {
             $this->errorcode = -1;
@@ -598,8 +618,8 @@ class cubeSQLServer
         try {
             $this->db = new csqldb($host, $port, $username, $password, $timeout);
         } catch (Exception $e) {
-            $this->errorCode = $this->db->errcode;
-            $this->errorMessage = $this->db->errmsg;
+            $this->errorCode = $this->db->errorcode;
+            $this->errorMessage = $this->db->errormsg;
             syslog(1, $e);
         }
 
@@ -628,9 +648,10 @@ class cubeSQLServer
             $kCOMMAND_EXECUTE = 3;
             $this->db->send_statement($kCOMMAND_EXECUTE, "USE DATABASE $database;");
             $this->db->netread(-1, -1);
+            // Test if an error occured
         } catch (Exception $e) {
-            $this->errorCode = $this->db->errcode;
-            $this->errorMessage = $this->db->errmsg;
+            $this->errorCode = $this->db->errorcode;
+            $this->errorMessage = $this->db->errormsg;
             syslog(1, "Database connection error: " . $this->errorMessage);
             //echo $e;
         }
@@ -652,8 +673,8 @@ class cubeSQLServer
             $this->db->send_statement($kCOMMAND_EXECUTE, $sql);
             $this->db->netread(-1, -1);
         } catch (Exception $e) {
-            $this->errorCode = $this->db->errcode;
-            $this->errorMessage = $this->db->errmsg;
+            $this->errorCode = $this->db->errorcode;
+            $this->errorMessage = $this->db->errormsg;
             syslog(1, $e);
             syslog(1, $this->errorCode);
             syslog(1, $this->errorMessage);
@@ -689,8 +710,8 @@ class cubeSQLServer
         try {
             $this->db->disconnect();
         } catch (Exception $e) {
-            $this->errorCode = $this->db->errcode;
-            $this->errorMessage = $this->db->errmsg;
+            $this->errorCode = $this->db->errorcode;
+            $this->errorMessage = $this->db->errormsg;
             syslog(1, $e);
         }
     }


### PR DESCRIPTION
### Fixed error handling
As described in issue #3 

### Code cleanup
* Replaced the indentation from tabs to spaces (1 Tab is replaced by 4 spaces)
* Converted the inline documentation to [PHPDoc](https://phpdoc.org/). Many PHP IDEs like PHP Storm are able to interpret these to link or show extra information on classes and methods. I only tried to complete the documentation for the cubeSQLServer class since this is the interface users are working with.
* Removed redundant php closing tags.