### PR TITLE
Fix strpos usage for PHP 8.x compatibility

### DIFF
--- a/PHP/Native/cubeSQLServer.php
+++ b/PHP/Native/cubeSQLServer.php
@@ -425,7 +425,7 @@ class csqldb
             $temp = $server_names;
             $data_seek = 0;
             for ($j = 0; $j < $server_colcount; $j++) {
-                $len = strpos($this->inbuffer, 0, $temp) - $temp + 1;
+                $len = strpos($this->inbuffer, chr(0), $temp) - $temp + 1;
                 $col_names[$j] = substr($this->inbuffer, $temp, $len - 1);
                 $data_seek += $len;
                 $temp += $len;
@@ -437,7 +437,7 @@ class csqldb
                 $server_tables = $server_data + $data_seek;
                 $temp = $server_tables;
                 for ($j = 0; $j < $server_colcount; $j++) {
-                    $len = strpos($this->inbuffer, 0, $temp) - $temp + 1;
+                    $len = strpos($this->inbuffer, chr(0), $temp) - $temp + 1;
                     $table_names[$j] = substr($this->inbuffer, $temp, $len - 1);
                     $data_seek += $len;
                     $temp += $len;


### PR DESCRIPTION
As per https://www.php.net/manual/de/function.strrpos.php:

"Prior to PHP 8.0.0, if needle is not a string, it is converted to an integer and applied as the ordinal value of a character. This behavior is deprecated as of PHP 7.3.0, and relying on it is highly discouraged. Depending on the intended behavior, the needle should either be explicitly cast to string, or an explicit call to chr() should be performed."